### PR TITLE
Fix compose navigation version

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,7 @@ ktor = "2.3.9"
 material = "1.11.0"
 maxSdk = "34"
 minSdk = "26"
+navigation = "2.7.7"
 settings = "1.1.1"
 versionCode = "1"
 versionName = "1.0"
@@ -64,7 +65,7 @@ kotlin-serialization = { module = "org.jetbrains.kotlin:kotlin-serialization", v
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
 material = { module = "com.google.android.material:material", version.ref = "material" }
 multiplatform-settings = { module = "com.russhwolf:multiplatform-settings-no-arg", version.ref = "settings" }
-navigation-compose = { module = "androidx.navigation:navigation-compose", version = "navigation" }
+navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigation" }
 preference = { module = "androidx.preference:preference-ktx", version = "1.2.1" }
 test-ext = { module = "androidx.test.ext:junit", version = "1.1.5" }
 


### PR DESCRIPTION
This was clearly being pulled in transitively, though I'd like to have it explicitly defined in the event I move away from Hilt (or whatever was providing it)